### PR TITLE
Added raw output tag in Blade templates section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1245,6 +1245,8 @@ View::creator('viewname', function($view){});
 {{ $var }}
 // Echo escaped content
 {{{ $var }}}
+// Echo unescaped content; 5.0 feature
+{!! $var !!}
 {{-- Blade Comment --}}
 // Echoing Data After Checking For Existence
 {{{ $name or 'Default' }}}


### PR DESCRIPTION
{!! $var !!} was added in Laravel 5.0. See the "Blade Tag Changes" section of the [Upgrade Guide](http://laravel.com/docs/5.1/upgrade#upgrade-5.0)

Here is a quote from that page.
#### Blade Tag Changes

For better security by default, Laravel 5.0 escapes all output from both the `{{ }}` and `{{{ }}}` Blade directives. A new `{!! !!}` directive has been introduced to display raw, unescaped output. The most secure option when upgrading your application is to only use the new `{!! !!}` directive when you are **certain** that it is safe to display raw output.

However, if you **must** use the old Blade syntax, add the following lines at the bottom of `AppServiceProvider@register`:

``` php
\Blade::setRawTags('{{', '}}');
\Blade::setContentTags('{{{', '}}}');
\Blade::setEscapedContentTags('{{{', '}}}');
```

This should not be done lightly, and may make your application more vulnerable to XSS exploits. Also, comments with `{{--` will no longer work.
